### PR TITLE
Remove database creation from init script

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,7 +1,3 @@
-CREATE DATABASE playwallet;
-
-\c playwallet;
-
 CREATE TABLE IF NOT EXISTS orders (
     id TEXT PRIMARY KEY,           -- ID заказа в PlayWallet
     external_id TEXT,              -- внешний ID (Plati id/inv/код)


### PR DESCRIPTION
## Summary
- remove database creation and connection commands from the initialization script so it can run against an existing database

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5bd305908333b640dea8f1c73494