### PR TITLE
Fix Prometheus config file quoting

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,4 +1,3 @@
-"""
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
@@ -24,4 +23,3 @@ scrape_configs:
   - job_name: 'node'
     static_configs:
       - targets: ['node_exporter:9100']
-"""


### PR DESCRIPTION
## Summary
- remove stray triple quotes from Prometheus configuration so the file is valid YAML

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5bd4247483339659d6e91755bbca