### PR TITLE
Update httpx pin in deploy script

### DIFF
--- a/deploy_v2.sh
+++ b/deploy_v2.sh
@@ -89,7 +89,7 @@ EOF
 sudo tee requirements.txt > /dev/null <<'EOF'
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
-httpx==0.27.2
+httpx==0.25.2
 asyncpg==0.29.0
 python-dotenv==1.0.1
 python-telegram-bot==20.7


### PR DESCRIPTION
## Summary
- align the httpx version pinned in `deploy_v2.sh` with the repository requirements by lowering it to 0.25.2

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68cd5bd4cdd08333aae4fc2652363eda