### PR TITLE
Handle missing database host configuration and fix health probe

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,11 +10,23 @@ PW_DEV_TOKEN = os.getenv("PW_DEV_TOKEN")
 PW_PROD_URL = os.getenv("PW_PROD_URL")
 PW_PROD_TOKEN = os.getenv("PW_PROD_TOKEN")
 
-DB_HOST = os.getenv("DB_HOST")
-DB_PORT = int(os.getenv("DB_PORT", 5432))
-DB_NAME = os.getenv("DB_NAME")
-DB_USER = os.getenv("DB_USER")
-DB_PASSWORD = os.getenv("DB_PASSWORD")
+def _get_env(name: str, default: str | None = None) -> str | None:
+    """Return environment variable value or fallback when missing/empty."""
+
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    return value
+
+
+DB_HOST = _get_env("DB_HOST", "db")
+try:
+    DB_PORT = int(_get_env("DB_PORT", "5432"))
+except ValueError:
+    DB_PORT = 5432
+DB_NAME = _get_env("DB_NAME")
+DB_USER = _get_env("DB_USER")
+DB_PASSWORD = _get_env("DB_PASSWORD")
 
 TG_BOT_TOKEN = os.getenv("TG_BOT_TOKEN")
 TG_CHAT_ID = os.getenv("TG_CHAT_ID")

--- a/app/db.py
+++ b/app/db.py
@@ -27,12 +27,28 @@ async def close_pool():
 
 async def get_conn():
     """Получить соединение из пула"""
+    if pool is None:
+        raise RuntimeError("Connection pool has not been initialised")
     return await pool.acquire()
 
 
 async def release_conn(conn):
     """Вернуть соединение в пул"""
+    if pool is None:
+        return
     await pool.release(conn)
+
+
+async def ping() -> None:
+    """Проверить доступность базы данных."""
+
+    conn = None
+    try:
+        conn = await get_conn()
+        await conn.execute("SELECT 1")
+    finally:
+        if conn is not None:
+            await release_conn(conn)
 
 
 async def insert_order(conn, **kwargs):


### PR DESCRIPTION
## Summary
- ensure the application falls back to the dockerized Postgres host when DB_HOST is not provided
- normalize database related environment variable reads so empty strings do not break startup
- guard DB_PORT parsing against invalid values
- add a reusable database ping helper and expose GET/HEAD handlers so the /health probe reliably reports readiness

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd76aac0048333a10ed23b5e154486