### PR TITLE
Ensure log directory accessible for topup service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y \
     libpq5 \
     curl \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r appuser && useradd -r -g appuser appuser
@@ -11,9 +12,11 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 RUN mkdir -p /app/logs && chown -R appuser:appuser /app
+COPY docker-entrypoint.sh /usr/local/bin/
 COPY . /app/
 WORKDIR /app
-USER appuser
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure the application logs directory exists and is owned by appuser
+if [ -d /app ]; then
+    mkdir -p /app/logs
+    chown -R appuser:appuser /app/logs
+fi
+
+# If we're root, drop privileges to appuser for the actual command
+if [ "$(id -u)" = "0" ]; then
+    exec gosu appuser "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a container entrypoint that fixes /app/logs ownership before starting the app and then drops privileges to appuser
- install gosu and wire the entrypoint into the Docker image so both the API and topup services can write log files when using bind mounts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd7af966388333927e15c598e32f02